### PR TITLE
Google認証機能を実装

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "temp-vite",
       "version": "0.0.0",
       "dependencies": {
+        "@react-oauth/google": "^0.12.2",
+        "jwt-decode": "^4.0.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -1042,6 +1044,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.2.tgz",
+      "integrity": "sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2592,6 +2604,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@react-oauth/google": "^0.12.2",
+    "jwt-decode": "^4.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,0 +1,42 @@
+import { GoogleLogin } from '@react-oauth/google';
+import type { CredentialResponse } from '@react-oauth/google';
+
+interface LoginProps {
+  onSuccess: (credentialResponse: CredentialResponse) => void;
+}
+
+function Login({ onSuccess }: LoginProps) {
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '100vh',
+      background: '#f5f5f5'
+    }}>
+      <div style={{
+        background: 'white',
+        padding: '40px',
+        borderRadius: '10px',
+        boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
+        textAlign: 'center'
+      }}>
+        <h1 style={{ marginBottom: '10px', color: '#333' }}>
+          SlidePilot
+        </h1>
+        <p style={{ marginBottom: '30px', color: '#666' }}>
+          AIスライド生成ツール
+        </p>
+        <GoogleLogin
+          onSuccess={onSuccess}
+          onError={() => {
+            console.log('Login Failed');
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default Login;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,14 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { GoogleOAuthProvider } from '@react-oauth/google'
+
+const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <GoogleOAuthProvider clientId={clientId}>
+      <App />
+    </GoogleOAuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## What?
Google OAuth 2.0認証機能をトップ画面に統合し、ユーザー認証・ログイン・ログアウト機能を実装しました。

## Why?
- ユーザーを識別・管理するための認証基盤が必要
- 将来的なユーザーごとのスライド履歴管理や利用制限機能の前提条件
- セキュアな認証方式（Google OAuth 2.0）により、パスワード管理の負担を軽減

## How?

### 実装したコンポーネント
1. **GoogleOAuthProvider** ([main.tsx](https://github.com/miyata09x0084/slide-pilot/blob/feature/google-auth-issue-1/frontend/src/main.tsx))
   - アプリ全体でGoogle認証APIを利用可能にするProvider
   - 環境変数からクライアントIDを読み込み

2. **Loginコンポーネント** ([Login.tsx](https://github.com/miyata09x0084/slide-pilot/blob/feature/google-auth-issue-1/frontend/src/components/Login.tsx))
   - Googleログインボタンを表示
   - 中央配置のシンプルなUI

3. **認証状態管理** ([App.tsx](https://github.com/miyata09x0084/slide-pilot/blob/feature/google-auth-issue-1/frontend/src/App.tsx))
   - `handleLoginSuccess`: GoogleのJWTトークンをデコードしてユーザー情報（名前・メール・プロフィール画像）を取得
   - `handleLogout`: ログアウト時にlocalStorageをクリア
   - `useEffect`: ページロード時にlocalStorageからセッションを復元
   - ユーザーヘッダー: プロフィール画像・名前・メールアドレス・ログアウトボタンを表示

### 技術スタック
- `@react-oauth/google` (v0.12.2): Google OAuth 2.0 React統合
- `jwt-decode` (v4.0.0): JWTトークンのデコード
- localStorage: セッション永続化

### UI改善
- `index.css`: `body`の`display: flex`を削除し、コンテンツが全幅表示されるように修正

## Testing?

### 動作確認済み項目
- [x] ログイン画面の表示（未認証時）
- [x] Googleアカウントでログイン成功
- [x] ログイン後のヘッダー表示（プロフィール画像・名前・メール）
- [x] ログアウト機能
- [x] ページリロード時のセッション復元（localStorage）
- [x] TypeScript型エラーなし（`type`インポートで解決）
- [x] 全幅表示の確認

### テスト手順
1. 開発サーバー起動: `cd frontend && npm run dev`
2. http://localhost:5174/ にアクセス
3. 「Googleでログイン」をクリック
4. Googleアカウントを選択してログイン
5. ヘッダーにユーザー情報が表示されることを確認
6. 「ログアウト」をクリックしてログイン画面に戻ることを確認
7. 再度ログイン後、ページをリロードしてセッションが維持されることを確認

## Screenshots (optional)

_(ログイン画面とログイン後の画面のスクリーンショットを追加予定)_

## Anything Else?

### ⚠️ 重要: Google Cloud Console設定が必要

このPRをマージ後、動作させるには以下の設定が必要です：

**Google Cloud Console → APIとサービス → 認証情報 → OAuth 2.0 クライアントID**
- **承認済みのJavaScript生成元:** `http://localhost:5174`
- **承認済みのリダイレクトURI:** `http://localhost:5174`

設定しないと以下のエラーが発生します：
```
エラー 400: origin_mismatch
このアプリは Google の OAuth 2.0 ポリシーを遵守していないため、ログインできません。
```

### セキュリティ考慮事項
- クライアントIDは`.env.local`で管理（`.gitignore`で除外済み）
- JWTトークンは localStorage に保存せず、デコード後のユーザー情報のみ保存
- 型安全性: TypeScriptの`type`インポートで型定義を明示

### 今後の改善案
- [ ] バックエンドでのJWT検証（現在はフロントエンドのみ）
- [ ] トークンのリフレッシュ機能
- [ ] ログイン失敗時のエラーハンドリング強化

---

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)