### PR TITLE
perf: Cloud Run min-instances=1でコールドスタート解消

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -79,7 +79,7 @@ jobs:
             --cpu=2 \
             --timeout=300 \
             --max-instances=100 \
-            --min-instances=0 \
+            --min-instances=1 \
             --set-secrets="$SECRETS" \
             --set-env-vars="$ENV_VARS"
 


### PR DESCRIPTION
## Summary
- Cloud Run の `min-instances` を `0` → `1` に変更
- アイドル後の初回リクエストで発生していた2-5秒のコールドスタートを解消

## 背景
PR #78 のTTLキャッシュで2回目以降のSupabaseクエリは高速化済みだが、Cloud Runインスタンス停止後の初回アクセスではコンテナ起動+Python起動+Supabaseクライアント初期化で2-5秒かかっていた。

## コスト影響
月額 ~$5-10 増（常時1インスタンス維持）

## Test plan
- [ ] デプロイ後、Cloud Runコンソールで min-instances=1 を確認
- [ ] しばらく放置後にアクセスし、即座にレスポンスが返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend deployment configuration to maintain minimum service instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->