### PR TITLE
chore: Cloud Run max-instances を100→5に制限

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -78,7 +78,7 @@ jobs:
             --memory=2Gi \
             --cpu=2 \
             --timeout=300 \
-            --max-instances=100 \
+            --max-instances=5 \
             --min-instances=1 \
             --set-secrets="$SECRETS" \
             --set-env-vars="$ENV_VARS"


### PR DESCRIPTION
## Summary
- `max-instances` を `100` → `5` に変更
- 意図しないスケールアウトによるコスト爆発を防止

## Test plan
- [ ] デプロイ後、Cloud Runコンソールで max-instances=5 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)