### PR TITLE
chore: α版バッジを削除

### DIFF
--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -57,24 +57,7 @@ export default function LoginPage() {
         }}
       >
         <h1 style={{ marginBottom: '10px', color: '#333' }}>
-          Multimodal Lab{' '}
-          <span
-            style={{
-              display: 'inline-block',
-              marginLeft: '8px',
-              padding: '2px 8px',
-              fontSize: '11px',
-              fontWeight: '600',
-              color: '#6b7280',
-              background: '#f3f4f6',
-              border: '1px solid #d1d5db',
-              borderRadius: '4px',
-              letterSpacing: '0.5px',
-              verticalAlign: 'middle',
-            }}
-          >
-            α版
-          </span>
+          Multimodal Lab
         </h1>
         <p style={{ marginBottom: '8px', color: '#666', fontWeight: '600' }}>
           Multimodal Content Experiment

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -46,18 +46,6 @@ const styles: Record<string, React.CSSProperties> = {
     color: "#1a1a1a",
     letterSpacing: "-0.5px",
   },
-  alphaBadge: {
-    display: "inline-block",
-    marginLeft: "10px",
-    padding: "2px 8px",
-    fontSize: "11px",
-    fontWeight: "600",
-    color: "#6b7280",
-    background: "#f3f4f6",
-    border: "1px solid #d1d5db",
-    borderRadius: "4px",
-    letterSpacing: "0.5px",
-  },
   userSection: {
     display: "flex",
     alignItems: "center",
@@ -302,7 +290,6 @@ export default function DashboardPage() {
         <div style={styles.logoSection}>
           <h1 style={styles.logo}>
             Multimodal Lab
-            <span style={styles.alphaBadge}>α版</span>
           </h1>
         </div>
 


### PR DESCRIPTION
## Summary
- ログインページとダッシュボードから「α版」バッジを削除
- 不要になったスタイル定義(`alphaBadge`)も除去

## Test plan
- [ ] ログインページでロゴが「Multimodal Lab」のみ表示されること
- [ ] ダッシュボードでロゴが「Multimodal Lab」のみ表示されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the alpha version badge (α版) that was displayed next to the Multimodal Lab title in the login and dashboard pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->