### PR TITLE
feat: 動画生成を「停止中」表示にする（LangGraph Cloud停止に伴うコスト削減）

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -50,6 +50,9 @@ jobs:
           # Supabase Configuration
           VITE_SUPABASE_URL=${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY=${{ secrets.VITE_SUPABASE_ANON_KEY }}
+
+          # 動画生成のON/OFF（未設定なら停止。再開するにはリポジトリ変数 VITE_GENERATION_ENABLED=true を設定）
+          VITE_GENERATION_ENABLED=${{ vars.VITE_GENERATION_ENABLED }}
           EOF
 
           echo "✅ Generated .env.production:"

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -7,3 +7,7 @@ VITE_API_URL=https://slidepilot-api-mripifvlwq-an.a.run.app/api
 # 注意: Firebase Hostingのドメインを承認済みのJavaScript生成元に追加する必要があります
 # https://console.cloud.google.com/apis/credentials
 VITE_GOOGLE_CLIENT_ID=692318722679-j74jo1d8gecscbsr970cnuuun176pblv.apps.googleusercontent.com
+
+# 動画生成機能のON/OFF（コスト削減のためLangGraph Cloud停止中はfalse）
+# 再開する際は true に変更して再デプロイする
+VITE_GENERATION_ENABLED=false

--- a/frontend/.env.schema.json
+++ b/frontend/.env.schema.json
@@ -30,6 +30,14 @@
       "required": true,
       "secret": false,
       "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+    },
+    {
+      "name": "VITE_GENERATION_ENABLED",
+      "description": "Toggle video generation. Set to false to suspend generation while LangGraph Cloud is stopped (cost saving). Defaults to disabled when unset.",
+      "required": false,
+      "secret": false,
+      "production": "false",
+      "development": "true"
     }
   ]
 }

--- a/frontend/src/config/env.ts
+++ b/frontend/src/config/env.ts
@@ -10,6 +10,9 @@ interface Env {
   GOOGLE_CLIENT_ID: string;
   SUPABASE_URL: string;
   SUPABASE_ANON_KEY: string;
+  // 動画生成機能の有効/無効。コスト削減のためLangGraph Cloudを停止している間はfalse。
+  // 既定は停止（false）。再開するには VITE_GENERATION_ENABLED=true を設定する。
+  GENERATION_ENABLED: boolean;
   MODE: string;
   DEV: boolean;
   PROD: boolean;
@@ -37,6 +40,7 @@ function getEnv(): Env {
     GOOGLE_CLIENT_ID: googleClientId || '',
     SUPABASE_URL: supabaseUrl || '',
     SUPABASE_ANON_KEY: supabaseAnonKey || '',
+    GENERATION_ENABLED: import.meta.env.VITE_GENERATION_ENABLED === 'true',
     MODE: import.meta.env.MODE,
     DEV: import.meta.env.DEV,
     PROD: import.meta.env.PROD,

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -14,6 +14,7 @@ import { useSamples } from "./api/get-samples";
 import { uploadPdf } from "./api/upload-pdf";
 import UnifiedCard from "./components/UnifiedCard";
 import QuickActionMenu from "./components/QuickActionMenu";
+import { env } from "@/config/env";
 
 const styles: Record<string, React.CSSProperties> = {
   container: {
@@ -217,8 +218,14 @@ export default function DashboardPage() {
     navigate("/login", { replace: true });
   };
 
-  // クイックメニューを開く
+  // クイックメニューを開く（生成停止中は案内のみ表示）
   const handleNewSlide = useCallback(() => {
+    if (!env.GENERATION_ENABLED) {
+      alert(
+        "動画生成は現在一時停止しています。\nサンプルや過去に生成した動画は引き続きご覧いただけます。"
+      );
+      return;
+    }
     setShowQuickMenu(true);
   }, []);
 
@@ -351,11 +358,15 @@ export default function DashboardPage() {
 
       {/* ユーザー動画グリッド */}
       <div className="dashboard-grid" style={styles.gridContainerNoTopPadding}>
-        {/* 新規作成 */}
+        {/* 新規作成（生成停止中は「停止中」を表示） */}
         <UnifiedCard
-          icon="📄"
-          title="新規作成"
-          subtitle="PDFから動画を生成"
+          icon={env.GENERATION_ENABLED ? "📄" : "🚧"}
+          title={env.GENERATION_ENABLED ? "新規作成" : "停止中"}
+          subtitle={
+            env.GENERATION_ENABLED
+              ? "PDFから動画を生成"
+              : "動画生成は一時停止しています"
+          }
           onClick={handleNewSlide}
           variant="primary"
           className="card-default"

--- a/frontend/src/features/generation/GenerationProgressPage.tsx
+++ b/frontend/src/features/generation/GenerationProgressPage.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useReactAgent } from './hooks/useReactAgent';
 import { uploadPdf } from '../dashboard/api/upload-pdf';
+import { env } from '@/config/env';
 
 // 処理ステータス
 type ProcessingStatus = 'uploading' | 'creating_thread' | 'generating' | 'completed' | 'error';
@@ -22,6 +23,8 @@ export default function GenerationProgressPage() {
 
   // PDF自動開始処理（アップロード完了時）
   useEffect(() => {
+    // 生成停止中はクラウドを呼ばない（コスト削減）
+    if (!env.GENERATION_ENABLED) return;
     if (!autoStart || hasStarted.current) return;
     hasStarted.current = true;
 
@@ -77,6 +80,56 @@ export default function GenerationProgressPage() {
       }, 2000);
     }
   }, [slideData, isThinking, isPollingVideo, navigate]);
+
+  // 生成停止中の表示（コスト削減のためLangGraph Cloudを停止中）
+  if (!env.GENERATION_ENABLED) {
+    return (
+      <div style={{
+        minHeight: '100vh',
+        background: '#f5f5f5',
+        fontFamily: 'Arial, sans-serif',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '40px 20px'
+      }}>
+        <div style={{
+          maxWidth: '560px',
+          width: '100%',
+          background: 'white',
+          borderRadius: '12px',
+          padding: '40px',
+          boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
+          textAlign: 'center'
+        }}>
+          <div style={{ fontSize: '56px', marginBottom: '16px' }}>🚧</div>
+          <h2 style={{ fontSize: '22px', fontWeight: 'bold', color: '#333', marginBottom: '12px' }}>
+            動画生成は一時停止中です
+          </h2>
+          <p style={{ fontSize: '14px', color: '#666', marginBottom: '28px', lineHeight: 1.7 }}>
+            現在、動画生成機能を一時的に停止しています。<br />
+            サンプルや過去に生成した動画は引き続きご覧いただけます。
+          </p>
+          <button
+            onClick={() => navigate('/', { replace: true })}
+            style={{
+              padding: '10px 20px',
+              fontSize: '14px',
+              background: '#3b82f6',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              fontWeight: 600
+            }}
+          >
+            ← ダッシュボードに戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div style={{


### PR DESCRIPTION
## 背景
LangGraph Cloud（LangGraph Platform）のデプロイ課金が高いため停止した。停止後はバックエンドの `/api/agent/*` プロキシ先が落ちるため、フロントからの動画生成は失敗する。ユーザーにはエラーではなく「停止中」を表示し、サンプル・過去動画の閲覧は継続できるようにする。

## 変更内容
- `VITE_GENERATION_ENABLED` フラグを追加（`config/env.ts`）。**未設定なら停止（既定 false）**、`true` で再開。
- ダッシュボードの「新規作成」カードを生成停止中は **🚧 停止中** 表示に変更し、クリックしても生成を起動せず案内のみ表示（`DashboardPage.tsx`）。
- 生成ページ `/generate` に直接来てもクラウドを呼ばず、停止中の案内画面を表示（`GenerationProgressPage.tsx`）。
- `deploy-frontend.yml` が再生成する `.env.production` に `VITE_GENERATION_ENABLED=${{ vars.VITE_GENERATION_ENABLED }}` を追加。リポジトリ変数が未設定なら停止のまま。
- フロントの env スキーマ／`.env.production` にフラグを追記。

## サンプル閲覧は維持
ダッシュボードのサンプル表示・`/slides/{id}` 詳細閲覧は生成フローと独立しているため無改修。停止中でもそのまま閲覧可能。

## デプロイ挙動
- 変更は `frontend/**` と `deploy-frontend.yml` のみ → マージ時は **Firebase Hosting のフロントデプロイのみ**発火（バックエンドは再デプロイされない）。
- CIのリポジトリ変数 `VITE_GENERATION_ENABLED` は現在未設定 → 本番ビルドは停止状態。

## 再開手順（将来）
GitHub → Settings → Secrets and variables → Actions → Variables に `VITE_GENERATION_ENABLED=true` を追加して再デプロイ。

## Test plan
- [x] `npm run build`（tsc + vite）成功
- [ ] マージ後、本番でダッシュボードが「停止中」表示になること
- [ ] サンプル・過去動画の閲覧が引き続き可能なこと
- [ ] `/generate` 直アクセスでクラウドを呼ばず停止中画面が出ること

https://claude.ai/code/session_019kdpdqwaWaoVPJZXwUR3WG

---
_Generated by [Claude Code](https://claude.ai/code/session_019kdpdqwaWaoVPJZXwUR3WG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video generation can now be disabled via configuration. When disabled, users see a paused status on the dashboard and new creation attempts display an alert explaining generation is unavailable.

* **Chores**
  * Added environment variable configuration to manage video generation availability across development and production environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miyata09x0084/learnify/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->