### PR TITLE
feat: 動画生成を再有効化（LangGraph Cloud再開に伴う）

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -51,8 +51,8 @@ jobs:
           VITE_SUPABASE_URL=${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY=${{ secrets.VITE_SUPABASE_ANON_KEY }}
 
-          # 動画生成のON/OFF（未設定なら停止。再開するにはリポジトリ変数 VITE_GENERATION_ENABLED=true を設定）
-          VITE_GENERATION_ENABLED=${{ vars.VITE_GENERATION_ENABLED }}
+          # 動画生成のON/OFF（未設定なら有効。一時停止するにはリポジトリ変数 VITE_GENERATION_ENABLED=false を設定）
+          VITE_GENERATION_ENABLED=${{ vars.VITE_GENERATION_ENABLED || 'true' }}
           EOF
 
           echo "✅ Generated .env.production:"

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -8,6 +8,6 @@ VITE_API_URL=https://slidepilot-api-mripifvlwq-an.a.run.app/api
 # https://console.cloud.google.com/apis/credentials
 VITE_GOOGLE_CLIENT_ID=692318722679-j74jo1d8gecscbsr970cnuuun176pblv.apps.googleusercontent.com
 
-# 動画生成機能のON/OFF（コスト削減のためLangGraph Cloud停止中はfalse）
-# 再開する際は true に変更して再デプロイする
-VITE_GENERATION_ENABLED=false
+# 動画生成機能のON/OFF（LangGraph Cloud稼働中は有効）
+# 一時停止する場合のみ false に変更して再デプロイする
+VITE_GENERATION_ENABLED=true

--- a/frontend/.env.schema.json
+++ b/frontend/.env.schema.json
@@ -33,10 +33,10 @@
     },
     {
       "name": "VITE_GENERATION_ENABLED",
-      "description": "Toggle video generation. Set to false to suspend generation while LangGraph Cloud is stopped (cost saving). Defaults to disabled when unset.",
+      "description": "Toggle video generation. Enabled while LangGraph Cloud is running. Set to false only to suspend generation (cost saving). Defaults to enabled when unset.",
       "required": false,
       "secret": false,
-      "production": "false",
+      "production": "true",
       "development": "true"
     }
   ]

--- a/frontend/src/config/env.ts
+++ b/frontend/src/config/env.ts
@@ -10,8 +10,8 @@ interface Env {
   GOOGLE_CLIENT_ID: string;
   SUPABASE_URL: string;
   SUPABASE_ANON_KEY: string;
-  // 動画生成機能の有効/無効。コスト削減のためLangGraph Cloudを停止している間はfalse。
-  // 既定は停止（false）。再開するには VITE_GENERATION_ENABLED=true を設定する。
+  // 動画生成機能の有効/無効。LangGraph Cloud稼働中は有効。
+  // 既定は有効。一時停止する場合のみ VITE_GENERATION_ENABLED=false を設定する。
   GENERATION_ENABLED: boolean;
   MODE: string;
   DEV: boolean;
@@ -40,7 +40,7 @@ function getEnv(): Env {
     GOOGLE_CLIENT_ID: googleClientId || '',
     SUPABASE_URL: supabaseUrl || '',
     SUPABASE_ANON_KEY: supabaseAnonKey || '',
-    GENERATION_ENABLED: import.meta.env.VITE_GENERATION_ENABLED === 'true',
+    GENERATION_ENABLED: import.meta.env.VITE_GENERATION_ENABLED !== 'false',
     MODE: import.meta.env.MODE,
     DEV: import.meta.env.DEV,
     PROD: import.meta.env.PROD,


### PR DESCRIPTION
## 概要

LangGraph Cloud の課金再開・稼働再開に合わせて、コスト削減のため停止していた動画生成機能をフロント側で再有効化します。

以前 PR #87 で `VITE_GENERATION_ENABLED` フラグ（既定 false）により生成UIを「停止中」表示にしていましたが、これを **デフォルトON**（明示的に `false` のときだけ停止）に反転し、**再デプロイするだけで機能が戻る**ようにしました。

## 変更内容

| ファイル | 変更 |
|---|---|
| `frontend/src/config/env.ts` | 判定を `=== 'true'` → `!== 'false'`（既定有効） |
| `frontend/.env.production` | `VITE_GENERATION_ENABLED=true` |
| `frontend/.env.schema.json` | production を `true` に、説明を更新 |
| `.github/workflows/deploy-frontend.yml` | リポジトリ変数未設定時は `'true'` をデフォルト |

これによりダッシュボードの「停止中」カードが「新規作成」に戻り、生成ページも通常動作に戻ります。

## マージ後に必要な手動作業 ⚠️

コードだけでは機能は完全には戻りません。以下はリポジトリ外の操作のため、別途対応が必要です。

1. **LangGraph Cloud（LangSmith）の課金・デプロイ再開**
   - https://smith.langchain.com → Deployments で停止中のデプロイメントを Resume し、課金プランが有効か確認。
2. **Cloud Run バックエンドの環境変数確認**
   - `backend/app/routers/agent.py` は本番時 `DEPLOYMENT_ID`（≠`local`）と `LANGGRAPH_CLOUD_URL` を参照。再稼働後の新しいデプロイメントURLが正しく設定されているか確認（URLが変わっている可能性あり）。
3. **GitHub リポジトリ変数の確認**
   - `VITE_GENERATION_ENABLED` は設定不要になりました（未設定＝有効）。以前 `false` が残っていれば削除してください。

## テスト

- フラグ判定の反転のみの低リスク変更。`node_modules` 未インストールのため型チェックは未実行。

https://claude.ai/code/session_0147SSQ4uLkzcGpDMwiCkoVY

---
_Generated by [Claude Code](https://claude.ai/code/session_0147SSQ4uLkzcGpDMwiCkoVY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Video generation feature is now enabled by default in production environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->