### PR TITLE
fix: LangGraph CloudデプロイのMROエラー解消（依存の版ズレ修正）

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,12 +9,14 @@ python-multipart>=0.0.6
 httpx>=0.25.0
 
 # LangChain / LangGraph stack ---
+# 注意: langgraph / langgraph-api / langgraph-cli は LangGraph Platform のランタイムが
+# 供給する（langgraph.json の dependencies: ["langgraph"] で宣言済み）。ここで pin すると
+# langchain-core との版ズレで PregelProtocol の MRO エラーが発生するため固定しない。
+# Cloud Run は FastAPI プロキシのみで langgraph を import しないため影響なし。
+# langchain-openai の <0.3.0 上限は古い langchain-core を強制し競合の原因になるため撤去。
 langchain-core>=0.3.64
-langchain-openai>=0.2.0,<0.3.0
-langgraph>=0.4.0
+langchain-openai>=0.2.0
 langgraph-sdk>=0.2.0
-langgraph-cli>=0.1.0
-langgraph-api>=0.0.1
 langsmith>=0.3.45
 
 # ---Compatibility helpers---


### PR DESCRIPTION
## 概要

LangGraph Cloud のデプロイがサーバ起動時に **`PregelProtocol` の MRO エラー**で失敗する問題を修正します。

```
TypeError: Cannot create a consistent method resolution order (MRO) for bases ABC, Generic
class PregelProtocol(Runnable[InputT, Any], Generic[StateT, InputT, OutputT], ABC):
```

## 原因

`backend/requirements.txt` の依存バージョンが時間経過でドリフトし、不整合になっていました（同じファイルで 2025-11 は成功していた）。

1. `langchain-openai>=0.2.0,<0.3.0` の **`<0.3.0` 上限**が古い `langchain-core` を強制
2. 一方 `langgraph>=0.4.0`（上限なし）が**最新 langgraph** を取得
3. → 新 langgraph の `PregelProtocol` と旧 langchain-core の `Runnable` の継承関係が衝突し MRO エラー
4. さらに `langgraph-api` / `langgraph-cli` は **LangGraph Platform が自前供給**するパッケージで、requirements での pin が競合を悪化

## 対応

- `langgraph` / `langgraph-api` / `langgraph-cli` を requirements から除去
  - `langgraph` は `langgraph.json` の `dependencies: ["langgraph"]` で Platform が供給
- `langchain-openai` の `<0.3.0` 上限を撤去（最新 langchain-core に追従）

## 影響範囲

- **Cloud Run**: FastAPI プロキシのみで `langgraph` を import しないため影響なし（Dockerfile も「LangGraph devサーバー削除」と明記、起動は `uvicorn app.main:app`）
- **LangGraph Cloud デプロイ**: Platform 供給の互換 langgraph で MRO 解消を狙う

## 検証

修正後、LangGraph Cloud で「New Revision」を実行しビルド/サーバ起動が通ることを確認予定。

参考: [langchain-ai/langgraph#5658](https://github.com/langchain-ai/langgraph/issues/5658)

https://claude.ai/code/session_0147SSQ4uLkzcGpDMwiCkoVY

---
_Generated by [Claude Code](https://claude.ai/code/session_0147SSQ4uLkzcGpDMwiCkoVY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated backend LangChain/LangGraph dependency configurations to improve runtime environment stability and prevent version constraint conflicts.
  * Relaxed upper-bound version constraints on specific packages while maintaining critical library pins for core functionality.
  * Streamlined dependency declarations to ensure cleaner runtime setup and improved system maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->