### PR TITLE
fix: langchain-text-splitters 追加でグラフ import エラー解消

### DIFF
--- a/backend/app/tools/pdf.py
+++ b/backend/app/tools/pdf.py
@@ -7,7 +7,7 @@ Issue #29: Supabase Storage対応
 
 from langchain_core.tools import tool
 from langchain_community.document_loaders import PyPDFLoader
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_text_splitters import RecursiveCharacterTextSplitter
 from pathlib import Path
 import json
 import tempfile

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,6 +34,7 @@ google-cloud-run>=0.10.0
 # ---PDF Processing (Issue #17)---
 pypdf>=3.17.0
 langchain-community>=0.3.0
+langchain-text-splitters>=0.3.0
 
 # ---Supabase (Issue #24)---
 supabase>=2.22.0


### PR DESCRIPTION
## 概要

LangGraph Cloud デプロイで `react-agent` グラフのロードが失敗する問題を修正します。前回 #90（MRO 解消）でビルドは進むようになりましたが、グラフ import 段階で次のエラーが発生:

```
File ".../app/tools/pdf.py", line 10, in <module>
    from langchain.text_splitter import RecursiveCharacterTextSplitter
ModuleNotFoundError: No module named 'langchain'
```

## 原因

`tools/pdf.py` が **`langchain` メタパッケージ**から `RecursiveCharacterTextSplitter` を import していたが、当該メタパッケージは依存に含まれていない。以前は削除した `langgraph-api` 等が間接的に `langchain` を引き込んでいたため動いていた。

## 対応

- import を modern な **`langchain_text_splitters`** に変更
- `requirements.txt` に `langchain-text-splitters>=0.3.0` を追加

## 検証

グラフ起動時にロードされる全モジュール（react_agent → tools/slides → slide_workflow → tools/pdf, gmail, core/*, prompts/*）のサードパーティ import を点検し、`langchain_text_splitters` 以外はすべて requirements でカバー済みであることを確認。`moviepy`/`playwright` 等は関数内の遅延 import で起動を妨げない。

https://claude.ai/code/session_0147SSQ4uLkzcGpDMwiCkoVY

---
_Generated by [Claude Code](https://claude.ai/code/session_0147SSQ4uLkzcGpDMwiCkoVY)_