### PR TITLE
feat: LLMをティア別に引き上げ（品質gpt-5.4 / 評価gpt-4.1配線）

### DIFF
--- a/backend/.env.schema.yml
+++ b/backend/.env.schema.yml
@@ -114,6 +114,21 @@ env_vars:
     description: Max images per slide deck
 
   # ─────────────────────────────────────────
+  # LLM model tiers
+  # ─────────────────────────────────────────
+  - name: LLM_QUALITY_MODEL
+    value: "gpt-5.4"
+    description: 品質ティア（本文生成・目次・タイトル・react判定）
+
+  - name: LLM_FAST_MODEL
+    value: "gpt-5.4-mini"
+    description: 高頻度/補助ティア（Map抽出・ナレーション・slug・ベンダー要約）
+
+  - name: LLM_EVAL_MODEL
+    value: "gpt-4.1"
+    description: 評価専用ティア（決定的採点＋安定JSON。temperature対応モデル必須）
+
+  # ─────────────────────────────────────────
   # LangSmith tracing
   # ─────────────────────────────────────────
   - name: LANGCHAIN_TRACING_V2

--- a/backend/app/agents/react_agent.py
+++ b/backend/app/agents/react_agent.py
@@ -9,13 +9,13 @@ Reasoning（思考）とActing（行動）を繰り返して複雑なタスク�
 """
 
 from dotenv import load_dotenv
-from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 from langgraph.graph import MessagesState
 from langsmith import traceable
 from typing_extensions import TypedDict
 
 # ツールのインポート
+from app.core.llm import get_llm
 from app.tools.gmail import send_gmail
 from app.tools.slides import generate_slides
 
@@ -27,11 +27,9 @@ import os
 os.environ.setdefault("LANGCHAIN_TRACING_V2", "true")
 os.environ.setdefault("LANGCHAIN_PROJECT", "react-agent")
 
-# LLM設定（GPT-4o）
-llm = ChatOpenAI(
-    model="gpt-4o",
-    temperature=0,  # 決定的な応答（再現性重視）
-)
+# LLM設定（品質ティア: ツール選択の信頼性を重視）
+# temperature=0 で決定的な応答（再現性重視）。temperature非対応モデルでは無視される。
+llm = get_llm("quality", temperature=0)
 
 # ツールリスト
 tools = [send_gmail, generate_slides]

--- a/backend/app/agents/slide_workflow.py
+++ b/backend/app/agents/slide_workflow.py
@@ -22,7 +22,7 @@ from langchain_core.runnables import RunnableConfig
 # ローカルモジュール
 from app.config import settings
 from app.core.config import TAVILY_API_KEY
-from app.core.llm import llm
+from app.core.llm import llm, llm_fast, llm_eval
 from app.core.supabase import save_slide_to_supabase
 from app.core.storage import upload_to_storage
 from app.core.utils import (
@@ -333,7 +333,7 @@ def generate_key_points(state: State) -> Dict:
       ]
 
       # 並列実行（最大5並列）
-      responses = llm.batch(batch_prompts, config={"max_concurrency": 5})
+      responses = llm_fast.batch(batch_prompts, config={"max_concurrency": 5})
 
       # 結果を統合
       chunk_points = []
@@ -673,7 +673,9 @@ def evaluate_slides_slidev(state: State) -> Dict:
     input_type=input_type
   )
   try:
-    msg = llm.invoke(prompt)
+    # 評価専用ティア（temperature対応モデル）で決定的に採点する。
+    # 品質ティア(GPT-5系)は temperature=1.0 固定のため採点がブレ、稀にJSONが壊れる。
+    msg = llm_eval.invoke(prompt)
     raw = msg.content or ""
     js = _find_json(raw) or raw
     data = json.loads(js)
@@ -730,7 +732,7 @@ def save_and_render_slidev(state: State) -> Dict:
   slug_prompt = get_slug_prompt(title=title)
 
   try:
-    emsg = llm.invoke(slug_prompt)
+    emsg = llm_fast.invoke(slug_prompt)
     file_stem = _slugify_en(emsg.content.strip()) or _slugify_en(title)
   except Exception:
     file_stem = _slugify_en(title) or "ai-latest-info"
@@ -972,7 +974,7 @@ def generate_narration(state: State) -> Dict:
         ]
 
         # 並列LLM実行（最大5並列）
-        responses = llm.batch(batch_prompts, config={"max_concurrency": 5})
+        responses = llm_fast.batch(batch_prompts, config={"max_concurrency": 5})
 
         # 結果を整形
         narrations = []

--- a/backend/app/core/llm.py
+++ b/backend/app/core/llm.py
@@ -1,10 +1,77 @@
-"""LLM クライアント初期化"""
+"""LLM クライアント初期化（tier別モデル選択）
+
+ノードの品質感度・頻度・決定性要求に応じて3つのティアを使い分ける:
+- quality: スライド本文生成・目次・タイトル・react判定など品質直結ノード（フロンティアモデル）
+- fast:    Map抽出・ナレーション・slug など高頻度/補助ノード（安価なminiモデル）
+- eval:    品質評価ノード。決定的な採点＋安定JSONのため temperature 対応モデルを使う
+
+モデル名は env 化済み。デフォルトのまま動作し、prod では .env.schema.yml 経由で上書き可能。
+"""
+
+import logging
+import os
 
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(
-  model="gpt-4o",  # 最新のGPT-4 Omniモデル（または "gpt-3.5-turbo" でコスト削減）
-  temperature=0.2,
-  max_retries=2,    # リトライ回数
-  # api_key は環境変数 OPENAI_API_KEY から自動読み込み
-)
+logger = logging.getLogger(__name__)
+
+# モデル名は env で上書き可（未設定でも以下のデフォルトで即動作）
+# quality は現行世代の gpt-5.4（旧既定 gpt-5.1 は 5.2 で非推奨化したため引き上げ）
+QUALITY_MODEL = os.getenv("LLM_QUALITY_MODEL", "gpt-5.4")
+FAST_MODEL = os.getenv("LLM_FAST_MODEL", "gpt-5.4-mini")
+# 評価専用ティア: 決定的な採点と安定したJSON出力が必要なため、temperature 対応の
+# gpt-4.1 を既定にする（GPT-5系は temperature=1.0 固定で採点がブレ、稀に壊れたJSONを出すため）。
+EVAL_MODEL = os.getenv("LLM_EVAL_MODEL", "gpt-4.1")
+
+_TIER_MODELS = {"quality": QUALITY_MODEL, "fast": FAST_MODEL, "eval": EVAL_MODEL}
+
+
+def _supports_temperature(model: str) -> bool:
+  """このモデルが任意の temperature 値を受け付けるか判定する。
+
+  GPT-5 / o 系（推論モデル）は temperature=1（既定値）しか受け付けず、0.2 や 0 を
+  渡すと API エラーになる。一方 gpt-4 系は任意の temperature を受け付け、評価ノード(E)
+  や react エージェントの判定安定性に活かせる。get_llm() はこの戻り値で「要求温度を
+  渡す」か「安全値 1.0 に固定する」かを切り替える。
+
+  Returns:
+    True なら任意の temperature を渡してよい（gpt-4 / gpt-3.5 系）。
+    False なら get_llm() は temperature=1.0 に固定する（GPT-5 / o / 未知モデル）。
+  """
+  name = (model or "").lower()
+  return name.startswith(("gpt-3.5", "gpt-4"))
+
+
+def get_llm(tier: str = "quality", *, temperature: float = 0.2) -> ChatOpenAI:
+  """ティア指定で ChatOpenAI クライアントを生成する。
+
+  Args:
+    tier: "quality"（既定）/ "fast" / "eval"。
+    temperature: 生成のばらつき。任意温度に対応しないモデルでは 1.0 に固定される。
+  """
+  model = _TIER_MODELS.get(tier, QUALITY_MODEL)
+  # langchain は temperature を必ず API に送る（未指定でも既定 0.7 を載せる）実装のため、
+  # 非対応モデルには唯一全モデルで受理される 1.0 を明示送信してエラーを防ぐ。
+  temp = temperature if _supports_temperature(model) else 1.0
+  return ChatOpenAI(model=model, temperature=temp, max_retries=2)
+
+
+# 後方互換: 既存の `from app.core.llm import llm` を壊さない
+# 既定 llm を品質ティアにすることで、未変更の import 先は自動で品質モデル化される。
+llm = get_llm("quality")              # 品質ティア（デフォルト）
+llm_fast = get_llm("fast")            # 高頻度/補助ティア
+llm_eval = get_llm("eval", temperature=0.0)  # 評価専用: 決定的採点＋安定JSON
+
+
+def _log_resolved_tiers() -> None:
+  """起動時に各ティアが解決したモデル名をログ出力する（設定ドリフト検知）。
+
+  本タスクの発端は「品質ティアが非推奨の gpt-5.1 のまま気付かれず放置されていた」こと。
+  起動ログに解決済みモデルを一度出しておけば、LangSmith / Cloud Run のログ一見で
+  『なぜ quality が古いモデル？』と気付ける（再発防止の安価なガード）。
+  参照可能: logger（logging.getLogger）, _TIER_MODELS（{"quality":..,"fast":..,"eval":..}）。
+  """
+  logger.info("LLM tiers resolved: %s", _TIER_MODELS)
+
+
+_log_resolved_tiers()

--- a/backend/app/core/utils.py
+++ b/backend/app/core/utils.py
@@ -21,7 +21,7 @@ import shutil
 import subprocess
 
 from app.core.config import TAVILY_API_KEY
-from app.core.llm import llm
+from app.core.llm import llm, llm_fast
 from app.config import settings
 
 # -------------------
@@ -309,7 +309,7 @@ def _create_llm_summarized_bullets(results: List[Dict], vendor_name: str = "Micr
   ]
 
   try:
-    msg = llm.invoke(prompt)
+    msg = llm_fast.invoke(prompt)
     lines = msg.content.strip().split("\n")
     bullets = [line.strip() for line in lines if line.strip().startswith("-")][:num_bullets]
 


### PR DESCRIPTION
## 目的
生成品質を上げつつコストを抑えるため、LLMを用途別の3ティア構成に整理し、各ティアのモデルを現行世代へ引き上げる。

## 背景
進行中だったティア化WIPが未コミット＝未デプロイで、**本番は旧ハードコードの `gpt-4o` 単一構成**で稼働していた（Cloud Run `slidepilot-api` に `LLM_*` env なしを確認）。品質ティアの既定が非推奨の `gpt-5.1` のままだった点、評価ティア(`gpt-4.1`)が定義のみで評価ノードに未配線だった点を是正する。

## 変更内容
| ティア | 用途 | モデル | 単価(in/out per 1M) |
|---|---|---|---|
| quality | 本文生成・目次・タイトル・react判定 | `gpt-5.1`→**`gpt-5.4`** | $2.50 / $15 |
| fast | Map抽出・ナレーション・slug・要約 | `gpt-5.4-mini` | $0.75 / $4.50 |
| eval | 品質評価ノード | `gpt-4.1`（**新規配線**） | temperature対応=決定的採点 |

- `core/llm.py`: quality既定を `gpt-5.4` に引き上げ／起動時に解決済みモデルを1行ログ出力（設定ドリフト検知）
- `agents/slide_workflow.py`: `llm_eval` をインポートし評価ノードへ配線（孤立バグ修正）。GPT-5系は temperature=1.0 固定で採点がブレるため評価のみ temperature対応モデルを使用
- `.env.schema.yml`: `LLM_EVAL_MODEL` を追加しコード既定と同期（quality値も `gpt-5.4` へ）

## 本番への影響
マージ→`deploy-backend` で Cloud Run env が全置換され、**本番が `gpt-4o` 単一 → 上記ティア構成へ切替**。`LLM_*` はSecretではなく平文env_varのため Secret Manager 操作は不要。ロールバックは旧リビジョンへ戻すだけ。

## 検証（実施済み）
- ✅ 4ファイル `py_compile` クリーン
- ✅ 実接続スモーク（ローカル実キー）: `gpt-5.4`→'OK' / `gpt-4.1`→`{"ok": true}` 疎通確認
- ✅ 起動ログ発火: `LLM tiers resolved: {'quality': 'gpt-5.4', 'fast': 'gpt-5.4-mini', 'eval': 'gpt-4.1'}`
- ✅ 評価ノードが `llm_eval.invoke` 使用（旧 `llm.invoke` 消滅）／グラフ compile 成功
- ✅ backend pytest 21/22 pass（失敗1は `test_auth_me_endpoint` の既存・認証系・本変更と無関係。stash検証済み）

## TODO（別タスク）
- [ ] デプロイ後、起動ログ `LLM tiers resolved` で実モデル確認
- [ ] フル生成e2e（graph.invoke）／Playwright e2eスイート整備
- [ ] 既存の `test_auth_me_endpoint` 失敗の修正（本PR対象外）