### PR TITLE
Revert: PR #93（LLMティア引き上げ）— 動画生成後の画面遷移が止まる不具合のため

### DIFF
--- a/backend/.env.schema.yml
+++ b/backend/.env.schema.yml
@@ -114,21 +114,6 @@ env_vars:
     description: Max images per slide deck
 
   # ─────────────────────────────────────────
-  # LLM model tiers
-  # ─────────────────────────────────────────
-  - name: LLM_QUALITY_MODEL
-    value: "gpt-5.4"
-    description: 品質ティア（本文生成・目次・タイトル・react判定）
-
-  - name: LLM_FAST_MODEL
-    value: "gpt-5.4-mini"
-    description: 高頻度/補助ティア（Map抽出・ナレーション・slug・ベンダー要約）
-
-  - name: LLM_EVAL_MODEL
-    value: "gpt-4.1"
-    description: 評価専用ティア（決定的採点＋安定JSON。temperature対応モデル必須）
-
-  # ─────────────────────────────────────────
   # LangSmith tracing
   # ─────────────────────────────────────────
   - name: LANGCHAIN_TRACING_V2

--- a/backend/app/agents/react_agent.py
+++ b/backend/app/agents/react_agent.py
@@ -9,13 +9,13 @@ Reasoning（思考）とActing（行動）を繰り返して複雑なタスク�
 """
 
 from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 from langgraph.graph import MessagesState
 from langsmith import traceable
 from typing_extensions import TypedDict
 
 # ツールのインポート
-from app.core.llm import get_llm
 from app.tools.gmail import send_gmail
 from app.tools.slides import generate_slides
 
@@ -27,9 +27,11 @@ import os
 os.environ.setdefault("LANGCHAIN_TRACING_V2", "true")
 os.environ.setdefault("LANGCHAIN_PROJECT", "react-agent")
 
-# LLM設定（品質ティア: ツール選択の信頼性を重視）
-# temperature=0 で決定的な応答（再現性重視）。temperature非対応モデルでは無視される。
-llm = get_llm("quality", temperature=0)
+# LLM設定（GPT-4o）
+llm = ChatOpenAI(
+    model="gpt-4o",
+    temperature=0,  # 決定的な応答（再現性重視）
+)
 
 # ツールリスト
 tools = [send_gmail, generate_slides]

--- a/backend/app/agents/slide_workflow.py
+++ b/backend/app/agents/slide_workflow.py
@@ -22,7 +22,7 @@ from langchain_core.runnables import RunnableConfig
 # ローカルモジュール
 from app.config import settings
 from app.core.config import TAVILY_API_KEY
-from app.core.llm import llm, llm_fast, llm_eval
+from app.core.llm import llm
 from app.core.supabase import save_slide_to_supabase
 from app.core.storage import upload_to_storage
 from app.core.utils import (
@@ -333,7 +333,7 @@ def generate_key_points(state: State) -> Dict:
       ]
 
       # 並列実行（最大5並列）
-      responses = llm_fast.batch(batch_prompts, config={"max_concurrency": 5})
+      responses = llm.batch(batch_prompts, config={"max_concurrency": 5})
 
       # 結果を統合
       chunk_points = []
@@ -673,9 +673,7 @@ def evaluate_slides_slidev(state: State) -> Dict:
     input_type=input_type
   )
   try:
-    # 評価専用ティア（temperature対応モデル）で決定的に採点する。
-    # 品質ティア(GPT-5系)は temperature=1.0 固定のため採点がブレ、稀にJSONが壊れる。
-    msg = llm_eval.invoke(prompt)
+    msg = llm.invoke(prompt)
     raw = msg.content or ""
     js = _find_json(raw) or raw
     data = json.loads(js)
@@ -732,7 +730,7 @@ def save_and_render_slidev(state: State) -> Dict:
   slug_prompt = get_slug_prompt(title=title)
 
   try:
-    emsg = llm_fast.invoke(slug_prompt)
+    emsg = llm.invoke(slug_prompt)
     file_stem = _slugify_en(emsg.content.strip()) or _slugify_en(title)
   except Exception:
     file_stem = _slugify_en(title) or "ai-latest-info"
@@ -974,7 +972,7 @@ def generate_narration(state: State) -> Dict:
         ]
 
         # 並列LLM実行（最大5並列）
-        responses = llm_fast.batch(batch_prompts, config={"max_concurrency": 5})
+        responses = llm.batch(batch_prompts, config={"max_concurrency": 5})
 
         # 結果を整形
         narrations = []

--- a/backend/app/core/llm.py
+++ b/backend/app/core/llm.py
@@ -1,77 +1,10 @@
-"""LLM クライアント初期化（tier別モデル選択）
-
-ノードの品質感度・頻度・決定性要求に応じて3つのティアを使い分ける:
-- quality: スライド本文生成・目次・タイトル・react判定など品質直結ノード（フロンティアモデル）
-- fast:    Map抽出・ナレーション・slug など高頻度/補助ノード（安価なminiモデル）
-- eval:    品質評価ノード。決定的な採点＋安定JSONのため temperature 対応モデルを使う
-
-モデル名は env 化済み。デフォルトのまま動作し、prod では .env.schema.yml 経由で上書き可能。
-"""
-
-import logging
-import os
+"""LLM クライアント初期化"""
 
 from langchain_openai import ChatOpenAI
 
-logger = logging.getLogger(__name__)
-
-# モデル名は env で上書き可（未設定でも以下のデフォルトで即動作）
-# quality は現行世代の gpt-5.4（旧既定 gpt-5.1 は 5.2 で非推奨化したため引き上げ）
-QUALITY_MODEL = os.getenv("LLM_QUALITY_MODEL", "gpt-5.4")
-FAST_MODEL = os.getenv("LLM_FAST_MODEL", "gpt-5.4-mini")
-# 評価専用ティア: 決定的な採点と安定したJSON出力が必要なため、temperature 対応の
-# gpt-4.1 を既定にする（GPT-5系は temperature=1.0 固定で採点がブレ、稀に壊れたJSONを出すため）。
-EVAL_MODEL = os.getenv("LLM_EVAL_MODEL", "gpt-4.1")
-
-_TIER_MODELS = {"quality": QUALITY_MODEL, "fast": FAST_MODEL, "eval": EVAL_MODEL}
-
-
-def _supports_temperature(model: str) -> bool:
-  """このモデルが任意の temperature 値を受け付けるか判定する。
-
-  GPT-5 / o 系（推論モデル）は temperature=1（既定値）しか受け付けず、0.2 や 0 を
-  渡すと API エラーになる。一方 gpt-4 系は任意の temperature を受け付け、評価ノード(E)
-  や react エージェントの判定安定性に活かせる。get_llm() はこの戻り値で「要求温度を
-  渡す」か「安全値 1.0 に固定する」かを切り替える。
-
-  Returns:
-    True なら任意の temperature を渡してよい（gpt-4 / gpt-3.5 系）。
-    False なら get_llm() は temperature=1.0 に固定する（GPT-5 / o / 未知モデル）。
-  """
-  name = (model or "").lower()
-  return name.startswith(("gpt-3.5", "gpt-4"))
-
-
-def get_llm(tier: str = "quality", *, temperature: float = 0.2) -> ChatOpenAI:
-  """ティア指定で ChatOpenAI クライアントを生成する。
-
-  Args:
-    tier: "quality"（既定）/ "fast" / "eval"。
-    temperature: 生成のばらつき。任意温度に対応しないモデルでは 1.0 に固定される。
-  """
-  model = _TIER_MODELS.get(tier, QUALITY_MODEL)
-  # langchain は temperature を必ず API に送る（未指定でも既定 0.7 を載せる）実装のため、
-  # 非対応モデルには唯一全モデルで受理される 1.0 を明示送信してエラーを防ぐ。
-  temp = temperature if _supports_temperature(model) else 1.0
-  return ChatOpenAI(model=model, temperature=temp, max_retries=2)
-
-
-# 後方互換: 既存の `from app.core.llm import llm` を壊さない
-# 既定 llm を品質ティアにすることで、未変更の import 先は自動で品質モデル化される。
-llm = get_llm("quality")              # 品質ティア（デフォルト）
-llm_fast = get_llm("fast")            # 高頻度/補助ティア
-llm_eval = get_llm("eval", temperature=0.0)  # 評価専用: 決定的採点＋安定JSON
-
-
-def _log_resolved_tiers() -> None:
-  """起動時に各ティアが解決したモデル名をログ出力する（設定ドリフト検知）。
-
-  本タスクの発端は「品質ティアが非推奨の gpt-5.1 のまま気付かれず放置されていた」こと。
-  起動ログに解決済みモデルを一度出しておけば、LangSmith / Cloud Run のログ一見で
-  『なぜ quality が古いモデル？』と気付ける（再発防止の安価なガード）。
-  参照可能: logger（logging.getLogger）, _TIER_MODELS（{"quality":..,"fast":..,"eval":..}）。
-  """
-  logger.info("LLM tiers resolved: %s", _TIER_MODELS)
-
-
-_log_resolved_tiers()
+llm = ChatOpenAI(
+  model="gpt-4o",  # 最新のGPT-4 Omniモデル（または "gpt-3.5-turbo" でコスト削減）
+  temperature=0.2,
+  max_retries=2,    # リトライ回数
+  # api_key は環境変数 OPENAI_API_KEY から自動読み込み
+)

--- a/backend/app/core/utils.py
+++ b/backend/app/core/utils.py
@@ -21,7 +21,7 @@ import shutil
 import subprocess
 
 from app.core.config import TAVILY_API_KEY
-from app.core.llm import llm, llm_fast
+from app.core.llm import llm
 from app.config import settings
 
 # -------------------
@@ -309,7 +309,7 @@ def _create_llm_summarized_bullets(results: List[Dict], vendor_name: str = "Micr
   ]
 
   try:
-    msg = llm_fast.invoke(prompt)
+    msg = llm.invoke(prompt)
     lines = msg.content.strip().split("\n")
     bullets = [line.strip() for line in lines if line.strip().startswith("-")][:num_bullets]
 


### PR DESCRIPTION
## 概要
PR #93（マージ `9791f09`「LLMをティア別に引き上げ gpt-5.4/gpt-4.1配線」）を**丸ごと revert** します。

## 背景（なぜ revert するか）
マージ直後から **動画は生成されるが、生成中画面から生成後画面へ遷移しない** 不具合が発生。

- PR #93 は**バックエンドのみ**の変更（LLMモデルのティア化）。フロントは0行も変更なし。
- だが画面遷移（`GenerationProgressPage.tsx:69-82`）は、`useReactAgent.ts:255-300` が
  **react-agent の流す `tool` 型SSEメッセージ（name=`generate_slides`）をパースして `slideData` をセット**
  することに依存している。
- PR #93 はそのオーケストレータを `gpt-4o → gpt-5.4`（`react_agent.py`）に変更。GPT-5系は
  出力構造・推論挙動が gpt-4o と異なり、**ツールはサーバ側で走り動画は生成されるのに、
  フロントが期待するメッセージ形を取れず `slideData` 未セット → 画面が遷移しない**。

→ PR #93 を revert して react-agent を gpt-4o に戻し、動作する状態へ復帰させる。

## 検証
- `git diff c1a6e41 <5 files>` が空（= pre-#93 の状態に完全一致）。
- `grep -rn "llm_fast\|llm_eval\|get_llm" backend` が0件（= 残存参照なし・自己完結）。
- 差分 `20 insertions(+), 102 deletions(-)` は PR #93 の正確な反転。

## フォローアップ（別タスク）
- 評価ティア修正（gpt-4.1 で採点安定化）は有用なので、フロント結合問題と切り離し**単独PRで再投入**。
- 根因対策: フロントの完了検知が react-agent のモデル出力形に暗黙依存している脆さを解消
  （ワークフロー側が明示的な完了イベント／安定スキーマを返す）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated multiple LLM model tiers into a single unified model configuration for improved system maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->